### PR TITLE
見出しとヘッダーの文言を多少修正&ICOの色を少しマイルドに

### DIFF
--- a/src/includes/navbar.pug
+++ b/src/includes/navbar.pug
@@ -16,7 +16,7 @@ nav.navbar.navbar-inverse.navbar-static-top.navbar-fixed-top
     #navbar.navbar-collapse.collapse
       ul.nav.navbar-nav
         li
-          a.smooth-anchor(href='#service-information') Documentation
+          a.smooth-anchor(href='#service-information') Whitepaper
         li
           a.smooth-anchor(href='#service-information') Roadmap
         li

--- a/src/index.pug
+++ b/src/index.pug
@@ -38,7 +38,7 @@ body
       .col-md-12#service-information
         img.service-information__logo(src='img/logo.png', alt='ALIS')
         h2.service-information__heading
-          | What is ALIS Project?
+          | What is ALIS Project
         .lead
           include:markdown-it ./contents/service-information.md
         p
@@ -51,7 +51,7 @@ body
   // Wrap the rest of the page in another container to center all the content.
   .container.features
     h2.features__heading
-      | 特徴
+      | Features
     .row.features__row
       .col-lg-4
         img.img-rounded.features__circle-image(src='img/first_circle.png', alt='トークン')
@@ -90,7 +90,7 @@ body
     .row
       .col-md-12
         h2.ico__heading
-          | ICO情報
+          | ICO
         img.technology__logo(src='img/ico.png', alt='ICO')
         .lead
           include:markdown-it ./contents/ico.md
@@ -103,7 +103,7 @@ body
     .row
       .col-md-12
         h2.technology__heading
-          | 技術
+          | Technology
         img.technology__logo(src='img/third_circle.jpg', alt='technology')
         .lead
           include:markdown-it ./contents/technology.md

--- a/src/scss/home.scss
+++ b/src/scss/home.scss
@@ -212,7 +212,7 @@ body {
 -------------------------------------------------- */
 
 .ico {
-  background-color: #05051e;
+  background-color: #1e242c;
   width: auto;
 
   .col-md-12 {


### PR DESCRIPTION
@sot528 
・見出しが日本語・英語で表記ゆれしていたので英語に統一
・ヘッダーのDocumantationをWhite paperに変更
　※変更しなくても良かったのですが、、、雰囲気出してみたかったため
・ICOの背景色を少しマイルドに

上記反映のご確認をお願いします！